### PR TITLE
9-delete-comment-by-id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -91,7 +91,7 @@ describe("/api/articles/:article_id", () => {
         .expect(400)
         .then((response) => {
           expect(response.body.msg).toBe(
-            "Bad request, invalid article_id/not a number"
+            "Bad request, invalid id/not a number"
           );
         });
     });
@@ -213,7 +213,7 @@ describe("/api/articles/:article_id/comments", () => {
         .expect(400)
         .then((response) => {
           expect(response.body.msg).toBe(
-            "Bad request, invalid article_id/not a number"
+            "Bad request, invalid id/not a number"
           );
         });
     });
@@ -264,7 +264,7 @@ describe("/api/articles/:article_id/comments", () => {
         .expect(400)
         .then((response) => {
           expect(response.body.msg).toBe(
-            "Bad request, invalid article_id/not a number"
+            "Bad request, invalid id/not a number"
           );
         });
     });
@@ -276,6 +276,34 @@ describe("/api/articles/:article_id/comments", () => {
         .expect(404)
         .then((response) => {
           expect(response.body.msg).toBe("Article not found");
+        });
+    });
+  });
+});
+
+describe("/api/comments/:comment_id", () => {
+  describe("DELETE", () => {
+    test("DELETE 204: should delete the given comment by comment_id", () => {
+      return request(app).delete("/api/comments/1").expect(204);
+    });
+
+    test("DELETE 404: should return status code 404 when comment_id is not found", () => {
+      return request(app)
+        .delete("/api/comments/999")
+        .expect(404)
+        .then((response) => {
+          expect(response.body.msg).toBe("Comment with provided ID not found");
+        });
+    });
+
+    test("DELETE 400: should return status code 400 for an invalid comment_id", () => {
+      return request(app)
+        .delete("/api/comments/nonsense")
+        .expect(400)
+        .then((response) => {
+          expect(response.body.msg).toBe(
+            "Bad request, invalid id/not a number"
+          );
         });
     });
   });

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const {
   getCommentsByArticleId,
   postCommentByArticleId,
   patchArticleById,
+  deleteCommentById,
 } = require("./controllers/articles.controller");
 
 const app = express();
@@ -28,11 +29,11 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 app.post("/api/articles/:article_id/comments", postCommentByArticleId);
 
+app.delete("/api/comments/:comment_id", deleteCommentById);
+
 app.use((err, req, res, next) => {
   if (err.code === "22P02") {
-    res
-      .status(400)
-      .send({ msg: "Bad request, invalid article_id/not a number" });
+    res.status(400).send({ msg: "Bad request, invalid id/not a number" });
   } else {
     next(err);
   }

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -4,6 +4,7 @@ const {
   fetchCommentsByArticleId,
   insertComment,
   updateArticleVotes,
+  deleteCommentById,
 } = require("../models/articles.model");
 
 exports.getArticleById = (req, res, next) => {
@@ -71,6 +72,18 @@ exports.patchArticleById = (req, res, next) => {
     .then(() => fetchArticleById(article_id))
     .then((updatedArticle) => {
       res.status(200).send({ article: updatedArticle });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteCommentById = (req, res, next) => {
+  const { comment_id } = req.params;
+
+  deleteCommentById(comment_id)
+    .then(() => {
+      res.status(204).send();
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -106,7 +106,12 @@
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
         }
       }
-    }
+    },
+
+  "DELETE /api/comments/:comment_id": {
+    "description": "will remove a comment by its comment_id, responds with no content",
+    "queries": ["comment_id", "comments"],
+    } 
   }
 
 

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -159,9 +159,24 @@ exports.updateArticleVotes = (article_id, inc_votes) => {
       `,
     [inc_votes, article_id]
   );
-  // .then(({ rows }) => {
-  //   if (rows.length === 0) {
-  //     return Promise.reject({ status: 400, msg: "Article ID not found" });
-  //   }
-  // });
+};
+
+exports.deleteCommentById = (comment_id) => {
+  return db
+    .query(
+      `
+    DELETE FROM comments
+    WHERE comment_id = $1
+    RETURNING *
+    `,
+      [comment_id]
+    )
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: "Comment with provided ID not found",
+        });
+      }
+    });
 };


### PR DESCRIPTION
Task 9 done
/api/comments/:comment_id
    DELETE
      ✓ DELETE 204: should delete the given comment by comment_id 
      ✓ DELETE 404: should return status code 404 when comment_id is not found
      ✓ DELETE 400: should return status code 400 for an invalid comment_id
